### PR TITLE
Fix Jekyll dependencies for Cayman theme

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,11 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3.2"
 gem "jekyll-remote-theme"
+gem "jekyll-seo-tag"
 
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
+  gem "jekyll-seo-tag"
 end
 
 platforms :mingw, :x64_mingw, :mswin, :jruby do

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
 remote_theme: pages-themes/cayman@v0.2.0
 plugins:
-- jekyll-remote-theme # add this line to the plugins list if you already have one
+- jekyll-remote-theme
+- jekyll-seo-tag


### PR DESCRIPTION
Add jekyll-seo-tag dependency required by Cayman theme to fix build errors