### PR TITLE
Fix Jekyll build by excluding application directories

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,24 @@ remote_theme: pages-themes/cayman@v0.2.0
 plugins:
 - jekyll-remote-theme
 - jekyll-seo-tag
+
+# Exclude directories that contain application code, not website content
+exclude:
+- WaterParser/
+- Tesla/
+- RachioFlume/
+- Bimpop.ai/
+- BrowserAlert/
+- GarageCheck/
+- LambdaEmailFwder/
+- NetworkCheck/
+- NodeCheck/
+- OpenAIAdmin/
+- WaterLogging/
+- lib/
+- scripts/
+- backups/
+- uv.lock
+- pyproject.toml
+- Makefile
+- .python-version


### PR DESCRIPTION
- Add exclude list to prevent Jekyll from processing Python application directories
- Fixes build errors caused by missing JavaScript files in WaterParser/html
- Only processes README.md and actual website content for GitHub Pages deployment