### PR TITLE
Use README.md as homepage instead of separate index.md

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,12 @@ source "https://rubygems.org"
 gem "jekyll", "~> 4.3.2"
 gem "jekyll-remote-theme"
 gem "jekyll-seo-tag"
+gem "jekyll-readme-index"
 
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-seo-tag"
+  gem "jekyll-readme-index"
 end
 
 platforms :mingw, :x64_mingw, :mswin, :jruby do

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,12 @@
+title: "Homely Vibes"
+description: "IoT Home Automation and Monitoring System"
+url: "https://homely-vibes.deviationlabs.com"
+
 remote_theme: pages-themes/cayman@v0.2.0
 plugins:
 - jekyll-remote-theme
 - jekyll-seo-tag
+- jekyll-readme-index
 
 # Exclude directories that contain application code, not website content
 exclude:


### PR DESCRIPTION
- Remove index.md file to avoid duplication with README.md
- Add jekyll-readme-index plugin to automatically use README.md as homepage  
- Update Gemfile and _config.yml with required plugin configuration
- Add site title and description for proper Cayman theme display
- This maintains single source of truth for project documentation