### PR TITLE
Fix submodule configuration and clean up Tesla README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ __pycache__/
 *.h5
 
 # hardcoded constants
-README.private.txt
 lib/Constants.py
 lib/Constants.sh
 lib/tuya_switch_config_cli.json
@@ -23,12 +22,6 @@ cache.json
 backups/
 nohup.out
 report.html
-# ext_lib/ contents ignored except for submodules
-ext_lib/*
-!ext_lib/TeslaPy/
+ext_lib*
 .env
 *.db
-
-# OpenAI automation logs
-openai-automation/openai_project_creation.log
-openai-automation/HackWeek2025.csv

--- a/Tesla/README.md
+++ b/Tesla/README.md
@@ -47,7 +47,7 @@ The system uses TeslaPy for Tesla API access. You'll need to authenticate once:
 
 ```bash
 # Run TeslaPy GUI for initial authentication
-cd ext_lib/TeslaPy
+cd lib/TeslaPy
 python gui.py
 ```
 
@@ -55,7 +55,7 @@ This will open a browser window for Tesla OAuth authentication. Follow the promp
 
 ## Usage
 
-All commands should be run from the Tesla directory:
+Run commands from the project root directory:
 
 ### Basic Power Management
 
@@ -159,21 +159,25 @@ uv run python -m pytest test_manage_power_clean.py::TestBatteryHistory -v
 If you see "Tesla token expired" errors:
 
 ```bash
-cd ../ext_lib/TeslaPy
+cd lib/TeslaPy
 python gui.py
 ```
 
 This will refresh your Tesla authentication token.
 
-### TeslaPy Not Found
+### TeslaPy Submodule Issues
 
-Ensure the ext_lib directory is properly created and TeslaPy is cloned:
+Ensure the TeslaPy submodule is properly initialized:
 
 ```bash
-ls -la ext_lib/TeslaPy/
+# Initialize submodules if not already done
+git submodule update --init --recursive
+
+# Verify TeslaPy is available
+ls -la lib/TeslaPy/
 ```
 
-You should see the TeslaPy files including `teslapy.py`.
+You should see the TeslaPy files including the `teslapy` directory.
 
 ### Constants Configuration
 


### PR DESCRIPTION
## Summary
- Fix stale Git submodule configuration causing `git submodule update --init --recursive` to fail
- Clean up Tesla README with correct TeslaPy paths and improved documentation
- Update .gitignore with user modifications

## Changes
- Remove stale `ext_lib/TeslaPy` submodule index entry that was conflicting with proper `lib/TeslaPy` configuration
- Fix all TeslaPy path references in Tesla README from `ext_lib/TeslaPy` to `lib/TeslaPy`
- Update command execution context to project root directory for consistency
- Improve troubleshooting section with proper Git submodule initialization commands
- Absorb .gitignore modifications

## Test plan
- [x] Verify `git submodule update --init --recursive` works without errors
- [x] Confirm TeslaPy submodule is properly accessible at `lib/TeslaPy`
- [x] Validate Tesla README instructions are accurate and consistent

🤖 Generated with [Claude Code](https://claude.ai/code)